### PR TITLE
Refactor and update mc_docx_update to accomodate new database changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ __pycache__/
 
 # Environments
 .venv/
+
+# Temporary directory
+.temp/

--- a/src/docx-etl.py
+++ b/src/docx-etl.py
@@ -4,57 +4,93 @@ import os
 import subprocess
 import requests
 
-#from dotenv import load_dotenv
-#load_dotenv() #for local secret management with .env file
+# TODO: This code is identical to the code of my latest draft in src\rss-etl.py. Consider refactoring to avoid duplication.
+DEBUG = True  # Set to True to print debug messages
+if DEBUG:
+    from dotenv import load_dotenv
+    load_dotenv()  # Load environment variables from .env file
+sb_api_url = os.environ["SUPABASE_API_URL"]  # github actions secret management
+sb_api_key = os.environ["SUPABASE_API_KEY"]  # github actions secret management
 
-senate_rss_feed = "https://www.legis.state.pa.us/WU01/LI/RSS/SenateBills.xml"
-house_rss_feed = "https://www.legis.state.pa.us/WU01/LI/RSS/HouseBills.xml"
 
-sb_api_url = "https://vsumrxhpkzegrktbtcui.supabase.co"
-#sb_api_key = os.getenv("SUPABASE_API_KEY") #local secret management wtih .env file
-sb_api_key = os.environ["SUPABASE_API_KEY"] #github actions secret management 
-
-def dowload_bill_doc_file(bill_link):
-    bill_link = bill_link.replace("txtType=HTM", "txtType=DOC") #change link to doc download
+def download_bill_doc_file(bill_link: str) -> str:
+    """
+    Downloads a .doc file from a given link
+    :param bill_link: link to the .doc file
+    :return: path to the downloaded .doc file
+    """
+    bill_link = bill_link.replace("txtType=HTM", "txtType=DOC")  # change link to doc download
     response = requests.get(bill_link, stream=True)
     output_file_name = "bill.doc"
-    with open(output_file_name, "wb") as f: #add try catch here and return empty filname if it fails
+    with open(output_file_name, "wb") as f:  # add try catch here and return empty filename if it fails
         f.write(response.content)
     return output_file_name
 
-def convert_doc_to_docx(bill_path):
-    new_file_name = ""
+
+def convert_doc_to_docx(bill_path: str) -> str:
+    """
+    Converts a .doc file to a .docx file using LibreOffice
+    :param bill_path: path to the .doc file
+    :return: path to the .docx file
+    """
     try:
         subprocess.call(['libreoffice', '--headless', '--convert-to', 'docx', bill_path])
-        new_file_name = bill_path.replace(".doc", ".docx")
+        return bill_path.replace(".doc", ".docx")
     except FileNotFoundError:
         raise FileNotFoundError(f"The file could not be found.")
-    return new_file_name
 
-def extract_law_text_from_docx(bill_path):
-    output_text = ""
+
+def extract_law_text_from_docx(bill_path: str) -> str:
+    """
+    Extracts the law text from a .docx file
+    :param bill_path: path to the .docx file
+    :return: extracted law text
+    """
+
+    # TODO: update to only include docs that haven't been posted yet
+    # TODO: find a way to determine when the actual bill text starts
     doc = Document(bill_path)
-
-    #update to only include docs that haven't been posted yet
-    # find a way to determine when the actual bill text starts
-
-    for para in doc.paragraphs:
-        for run in para.runs: #not sure what runs are, but these for loops seem to look through on a character by character basis (testing by strikethroughing a single character and this picks it up as an individual run)
-            if not run.font.strike: #only extract text that isn't strikethrough 
+    output_text = ""
+    for paragraph in doc.paragraphs:
+        for run in paragraph.runs:  # not sure what runs are, but these for loops seem to look through on a character by character basis (testing by strikethroughing a single character and this picks it up as an individual run)
+            if not run.font.strike:  # only extract text that isn't strikethrough
                 output_text += run.text
-        output_text += ' ' #resolves spacing issues
+        output_text += ' '  # resolves spacing issues
     return output_text
 
-def extract_and_upload_missing_bill_text(supa_con):
+
+def extract_and_upload_missing_bill_text(supa_con: Client):
+    """
+    Extracts the law text from a .docx file and uploads it to Supabase
+    :param supa_con: Supabase connection object
+    """
+    # TODO: Modify so that this might also pull records which have not had a summary prior to a certain date
     bill_records_missing_text = supa_con.table("Revisions").select("*").filter("full_text", "is", "null").execute()
     for record in bill_records_missing_text.data:
-        bill_path = dowload_bill_doc_file(record["full_text_link"])
+        bill_path = download_bill_doc_file(record["full_text_link"])
         bill_docx_path = convert_doc_to_docx(bill_path)
         bill_text = extract_law_text_from_docx(bill_docx_path)
         os.remove(bill_path)
         os.remove(bill_docx_path)
-        supa_con.table('Revisions').update({ "full_text": bill_text }).eq("bill_id", record["bill_id"]).eq("printer_no", record["printer_no"]).eq("legislative_body", record["legislative_body"]).eq("full_text_link", record["full_text_link"]).execute()
-    return
+        upload_bill_text(supa_con, bill_text, record["revision_guid"])
+
+
+def upload_bill_text(supa_con: Client, full_text: str, revision_guid: str):
+    """
+    Uploads the law text from a .docx file to Supabase's "Revision_Text" table,
+    linking it to the appropriate entry in the "Revisions" table
+    :param supa_con: Supabase connection object
+    :param full_text: full text of the bill revision
+    :param revision_guid: guid of the bill revision
+    """
+
+    # Insert full text as entry in Revision_Text table, retrieving the rt_unique_id of the new entry
+    # TODO: Check that this function returns the rt_unique_id of the new entry
+    rt_unique_id = supa_con.table('Revision_Text').insert({"full_text": full_text}).execute()
+
+    # Update relevant entry in Revisions table (found with revision guid) with rt_unique_id of  new entry in Revision_Text table
+    supa_con.table('Revisions').update({"rt_unique_id": rt_unique_id}).eq("revision_guid", revision_guid).execute()
+
 
 if __name__ == "__main__":
     supabase_connection: Client = create_client(sb_api_url, sb_api_key)

--- a/tests/sql/setup_test_docx_etl.sql
+++ b/tests/sql/setup_test_docx_etl.sql
@@ -6,6 +6,7 @@ values(
    '0',
    'HOUSE'
 )
+on conflict (legislative_id) do nothing;
 
 insert into "Revisions" (revision_guid, printer_no, full_text_link, publication_date, description, bill_internal_id)
 values(
@@ -16,3 +17,4 @@ values(
   'An Act amending the act of March 10, 1949 (P.L.30, No.14), known as the Public School Code of 1949, in terms and courses of study, further providing for Commission for Agricultural Education Excellence....',
   (SELECT bill_internal_id from "Bills" where legislative_id like '20230HB1540')
 )
+on conflict (revision_guid) do nothing;

--- a/tests/sql/setup_test_docx_etl.sql
+++ b/tests/sql/setup_test_docx_etl.sql
@@ -1,0 +1,18 @@
+insert into "Bills" (legislative_id, legislative_session, bill_number, session_type, chamber)
+values(
+   '20230HB1540',
+   '2023',
+   '1540',
+   '0',
+   'HOUSE'
+)
+
+insert into "Revisions" (revision_guid, printer_no, full_text_link, publication_date, description, bill_internal_id)
+values(
+  '20230HB1540P2050',
+  '2050',
+  'https://www.legis.state.pa.us/cfdocs/legis/PN/Public/btCheck.cfm?txtType=HTM&sessYr=2023&sessInd=0&billBody=H&billTyp=B&billNbr=1540&pn=2050',
+  'Fri, 13 Oct 2023 13:04:20 GMT',
+  'An Act amending the act of March 10, 1949 (P.L.30, No.14), known as the Public School Code of 1949, in terms and courses of study, further providing for Commission for Agricultural Education Excellence....',
+  (SELECT bill_internal_id from "Bills" where legislative_id like '20230HB1540')
+)


### PR DESCRIPTION
## What I did

Add comments and type hinting
Add print statements indicating status of conversion process. 
Light refactoring
Modify which tables are modified and how during update/insertion
Added SQL script for inserting test data (currently only one case)

## Why I did it

Modifying script in accordance with database changes as well as prepping for data loading. 

## Issue #s Addressed

https://trello.com/c/HmsXVeVk/30-script-that-takes-link-to-bill-and-extracts-text-from-bill

## How to test it

1. Will need to setup local Supabase DB on Docker.
2. In addition to setting up schema data, will need to run scripts in `tests/sql/setup_test_docx_etl.sql` 
3.  I used ubuntu in VM via PyCharm. We probably need a docker-based way of testing it, but not sure how that would work at this moment.
4. In vm, type `sudo apt install libreoffice`
5. Run `pip install [package]` for the following packages: python-docx, supabase, python-dotenv
6. Run `python src/docx-etl.py`

Will need dev version of DB as well as a handful of test entries created in Revisions table with links to the actual bills. Haven't yet developed that script. 