### PR TITLE
Add apt-get update to libreoffice install

### DIFF
--- a/.github/workflows/rss_and_docx_etl.yaml
+++ b/.github/workflows/rss_and_docx_etl.yaml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install requests
       - name: Install Libreoffice for doc to docx conversion
         run: |
-          apt-get update
+          sudo apt-get update
           sudo apt install libreoffice
       - name: Run DOCX Text extraction script
         run: python law_reader/docx-etl.py

--- a/.github/workflows/rss_and_docx_etl.yaml
+++ b/.github/workflows/rss_and_docx_etl.yaml
@@ -44,7 +44,7 @@ jobs:
           python -m pip install python-dotenv
           python -m pip install requests
       - name: Install Libreoffice for doc to docx conversion
-        run:
+        run: |
           apt-get update
           sudo apt install libreoffice
       - name: Run DOCX Text extraction script

--- a/.github/workflows/rss_and_docx_etl.yaml
+++ b/.github/workflows/rss_and_docx_etl.yaml
@@ -45,6 +45,7 @@ jobs:
           python -m pip install requests
       - name: Install Libreoffice for doc to docx conversion
         run:
+          apt-get update
           sudo apt install libreoffice
       - name: Run DOCX Text extraction script
         run: python law_reader/docx-etl.py


### PR DESCRIPTION
The RSS-DOCX action was running into an error when installing libreoffice. I added a line to run **apt-get update** before the libreoffice install and it appears to have fixed it.

Error was:

"E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/p/poppler/libpoppler118_22.02.0-2ubuntu0.2_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?"
