### PR TITLE
Refactor to Reduce Coupling. Remove clunky DB unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Then run commands inside a virtual environemnt with the dependencies installed:
 $ pipenv run python src/hello_world.py
 ```
 
-For more details, see: https://pipenv.pypa.io/en/latest/
+For more details, see: https://pipenv.pypa.io/en/latest

--- a/law_reader/__init__.py
+++ b/law_reader/__init__.py
@@ -1,3 +1,4 @@
 from law_reader.common import *
 from law_reader.rss_etl import *
 from law_reader.summarizer import *
+from law_reader.db_interfaces import *

--- a/law_reader/db_interfaces/DBInterface.py
+++ b/law_reader/db_interfaces/DBInterface.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+
+from law_reader.common.RevisionSummaryInfo import RevisionSummaryInfo
+
+
+class DBInterface(ABC):
+    """
+    Interface for database classes.
+    This is created to ensure that all database classes have the same methods, and to enhance unit testing.
+    As well as to guide the implementation or replacement of the database classes.
+    This class is meant to be inherited by other classes.
+    All methods in this class are meant to be overridden.
+    """
+
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def download_bill_text(self, revison_internal_id: int) -> str:
+        """
+        Downloads the full text of a bill from the database
+        :param revison_internal_id: the unique id of the bill
+        :return: the full text of the bill
+        """
+        pass
+
+    def upload_summary(self, revision_info: RevisionSummaryInfo, summary_text: str):
+        """
+        Uploads a summary to the database, linking it to the appropriate entry in the "Revisions" table
+        :param revision_info: the unique id of the bill
+        :param summary_text: the text of the summary
+        """
+        pass
+
+    def get_revisions_without_summaries(self) -> list[RevisionSummaryInfo]:
+        """
+        Gets the unique ids of all bills without summaries
+        :return: a list of unique ids of bills without summaries
+        """
+        pass

--- a/law_reader/db_interfaces/SupabaseDBInterface.py
+++ b/law_reader/db_interfaces/SupabaseDBInterface.py
@@ -1,0 +1,75 @@
+import os
+
+from postgrest.types import CountMethod
+from supabase import Client
+from supabase._async.client import create_client
+
+from law_reader.common import RevisionSummaryInfo
+from law_reader.db_interfaces.DBInterface import DBInterface
+from law_reader.summarizer.InvalidRTUniqueIDException import InvalidRTUniqueIDException
+
+
+class SupabaseDBInterface(DBInterface):
+
+    """
+    Interface for Supabase database classes.
+    """
+    def __init__(self, debug=False):
+        super().__init__()
+        # if debug flag is set, pull data from .env file
+        # In production, the environment variables will be set in the github actions workflow
+        if debug:
+            from dotenv import load_dotenv
+            load_dotenv()  # Load environment variables from .env file
+        sb_api_url = os.environ["SUPABASE_API_URL"]  # github actions secret management
+        sb_api_key = os.environ["SUPABASE_API_KEY"]  # github actions secret management
+
+        self.supabase_connection: Client = create_client(sb_api_url, sb_api_key)
+
+    def download_bill_text(self, revison_internal_id: str) -> str:
+        """
+        Downloads the full text of a bill from Supabase, using the rt_unique_id
+        Raises an InvalidRTUniqueIDException if the bill cannot be found
+         or if multiple bills are found with the given rt_unique_id
+        :param revison_internal_id: the unique id of the bill in the Revision_Text table
+        :return: the full text of the bill
+        """
+        api_response = self.supabase_connection.table("Revision_Text").select("full_text").eq("rt_unique_id",
+                                                                                              revison_internal_id).execute()
+        if len(api_response.data) == 0:
+            raise InvalidRTUniqueIDException(f"Could not find bill with rt_unique_id {revison_internal_id}")
+        elif len(api_response.data) > 1:
+            raise InvalidRTUniqueIDException(f"Found multiple bills with rt_unique_id {revison_internal_id}")
+        text = api_response.data[0]["full_text"]
+        if text is None or text == "":
+            raise InvalidRTUniqueIDException(f"Bill with rt_unique_id {revison_internal_id} has no text")
+        return text
+
+    def upload_summary(self, revision_info: RevisionSummaryInfo, summary_text: str):
+        """
+        Uploads a summary to Supabase, linking it to the appropriate entry in the "Revisions" table
+        :param supabase_connection: a Supabase connection object
+        :param revision_info: a RevisionSummaryInfo object containing information about the revision
+        :param summary_text: the text of the summary
+        """
+        # Insert summary into Summaries table and retrieve the summary_id of the new entry
+        api_response = self.supabase_connection.table("Summaries").insert(
+            {"summary_text": summary_text,
+             "revision_internal_id": revision_info.revision_internal_id}). \
+            execute()
+        summary_id = api_response.data[0]["summary_id"]
+        # Update relevant entry in Revisions table (found with revision guid) with summary_id of new entry in Summaries table
+        self.supabase_connection.table("Revisions"). \
+            update({"active_summary_id": summary_id}). \
+            eq("revision_guid", revision_info.revision_guid). \
+            execute()
+
+    def get_revisions_without_summaries(self) -> list[RevisionSummaryInfo]:
+        """
+        Gets the unique ids of all bills without summaries
+        :return: a list of unique ids of bills without summaries
+        """
+        api_response = self.supabase_connection.table("Revisions").select("revision_guid", "rt_unique_id", "revision_internal_id", count=CountMethod.exact).\
+            is_("active_summary_id", "NULL").\
+            execute()
+        return [RevisionSummaryInfo(revision["revision_guid"], revision["rt_unique_id"], revision["revision_internal_id"]) for revision in api_response.data]

--- a/law_reader/db_interfaces/__init__.py
+++ b/law_reader/db_interfaces/__init__.py
@@ -1,0 +1,2 @@
+from .DBInterface import *
+from .SupabaseDBInterface import *

--- a/law_reader/summarize_etl.py
+++ b/law_reader/summarize_etl.py
@@ -2,6 +2,7 @@ from supabase import create_client, Client
 import os
 import argparse
 
+from law_reader.db_interfaces import SupabaseDBInterface, DBInterface
 from law_reader.common.RevisionSummaryInfo import RevisionSummaryInfo
 from law_reader.summarizer.InvalidRTUniqueIDException import InvalidRTUniqueIDException
 from law_reader.summarizer.SummarizationException import SummarizationException
@@ -17,18 +18,6 @@ Pulls data from:
 The database tables updated by this script are:
 - Summaries
 """
-def get_revisions_without_summaries(supabase_connection: Client) -> list[RevisionSummaryInfo]:
-    """
-    Pulls all revisions from Supabase that do not have a summary
-    A revision is considered to have a summary if its active_summary_id column in the REVISIONS table is not NULL
-    :param supabase_connection: a Supabase connection object
-    :return: a list of revisions without summaries
-    """
-    api_response = supabase_connection.table("Revisions").select("*", count="exact").is_("active_summary_id", "NULL").execute()
-    # Put relevant information from each entry into a RevisionTextInfo object
-    results = [RevisionSummaryInfo(entry["revision_guid"], entry["rt_unique_id"], entry["revision_internal_id"]) for entry in api_response.data]
-    return results
-
 def summarize_bill(bill_text: str) -> str:
     """
     A placeholder function for summarizing a bill
@@ -40,59 +29,19 @@ def summarize_bill(bill_text: str) -> str:
     summarizer = Summarization()
     return summarizer.get_summary(bill_text)
 
-
-def download_bill_text(supabase_connection: Client, rt_unique_id: int) -> str:
-    """
-    Downloads the full text of a bill from Supabase, using the rt_unique_id
-    Raises an InvalidRTUniqueIDException if the bill cannot be found
-     or if multiple bills are found with the given rt_unique_id
-    :param supabase_connection: a Supabase connection object
-    :param rt_unique_id: the unique id of the bill in the Revision_Text table
-    :return: the full text of the bill
-    """
-    api_response = supabase_connection.table("Revision_Text").select("full_text").eq("rt_unique_id", rt_unique_id).execute()
-    if len(api_response.data) == 0:
-        raise InvalidRTUniqueIDException(f"Could not find bill with rt_unique_id {rt_unique_id}")
-    elif len(api_response.data) > 1:
-        raise InvalidRTUniqueIDException(f"Found multiple bills with rt_unique_id {rt_unique_id}")
-    text = api_response.data[0]["full_text"]
-    if text is None or text == "":
-        raise InvalidRTUniqueIDException(f"Bill with rt_unique_id {rt_unique_id} has no text")
-    return text
-
-def upload_summary(supabase_connection: Client, revision_info: RevisionSummaryInfo, summary_text: str):
-    """
-    Uploads a summary to Supabase, linking it to the appropriate entry in the "Revisions" table
-    :param supabase_connection: a Supabase connection object
-    :param revision_info: a RevisionSummaryInfo object containing information about the revision
-    :param summary_text: the text of the summary
-    """
-    # Insert summary into Summaries table and retrieve the summary_id of the new entry
-    api_response = supabase_connection.table("Summaries").insert(
-        {"summary_text": summary_text,
-         "revision_internal_id": revision_info.revision_internal_id}).\
-        execute()
-    summary_id = api_response.data[0]["summary_id"]
-    # Update relevant entry in Revisions table (found with revision guid) with summary_id of new entry in Summaries table
-    supabase_connection.table("Revisions").\
-        update({"active_summary_id": summary_id}).\
-        eq("revision_guid", revision_info.revision_guid).\
-        execute()
-
-
-def summarize_all_unsummarized_revisions(supabase_connection: Client):
+def summarize_all_unsummarized_revisions(db_interface: DBInterface):
     """
     Downloads the full text of all bills without summaries from Supabase,
     summarizes them, and uploads the summaries to Supabase
     Any bills that cannot be summarized will be skipped
-    :param supabase_connection: a Supabase connection object
+    :param db_interface: Interface to the database
     """
-    revisions_without_summaries = get_revisions_without_summaries(supabase_connection)
+    revisions_without_summaries: list[RevisionSummaryInfo] = db_interface.get_revisions_without_summaries()
     for revision_info in revisions_without_summaries:
         try:
-            full_text = download_bill_text(supabase_connection, revision_info.rt_unique_id)
+            full_text = db_interface.download_bill_text(revision_info.rt_unique_id)
             summary_text = summarize_bill(full_text)
-            upload_summary(supabase_connection, revision_info, summary_text)
+            db_interface.upload_summary(revision_info, summary_text)
         except SummarizationException:
             continue
         except InvalidRTUniqueIDException:
@@ -100,22 +49,11 @@ def summarize_all_unsummarized_revisions(supabase_connection: Client):
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(description="Summarize bills from Database")
-
     # Add a boolean argument for the debug flag
     parser.add_argument('-d', '--debug', action='store_true', help='Print debug messages')
-
     # Parse the arguments
     args = parser.parse_args()
+    db_interface: DBInterface = SupabaseDBInterface(args.debug)
 
-    # if debug flag is set, pull data from .env file
-    # In production, the environment variables will be set in the github actions workflow
-    if args.debug:
-        from dotenv import load_dotenv
-        load_dotenv()  # Load environment variables from .env file
-    sb_api_url = os.environ["SUPABASE_API_URL"]  # github actions secret management
-    sb_api_key = os.environ["SUPABASE_API_KEY"]  # github actions secret management
-
-    supabase_connection: Client = create_client(sb_api_url, sb_api_key)
-    summarize_all_unsummarized_revisions(supabase_connection)
+    summarize_all_unsummarized_revisions(db_interface)

--- a/law_reader/summarizer/summarization.py
+++ b/law_reader/summarizer/summarization.py
@@ -7,17 +7,14 @@ This module provides a class for generating summaries of text using OpenAI's GPT
 """
 
 import os
-import openai
 
 from langchain.chat_models import ChatOpenAI
 from langchain.chains import LLMChain
-from langchain.prompts import PromptTemplate
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from langchain.prompts import PromptTemplate
 from langchain.docstore.document import Document
-from langchain.chains.summarize import load_summarize_chain
 from langchain.vectorstores import Chroma
 from langchain.embeddings import GPT4AllEmbeddings
 
@@ -38,15 +35,10 @@ class Summarization(Summarizer):
     def get_text_chunks_into_docs(self, text: str) -> list[Document]:
         """
         Splits the given text into chunks using CharacterTextSplitter and returns a list of Document objects.
-
         **Parameters:**
-
         text (str): The text to be split into chunks.
-
         **Returns:**
-
         list[Document]: A list of Document objects representing the text chunks.
-
         """
         try:
             text_splitter = CharacterTextSplitter(chunk_size=500, chunk_overlap=100)
@@ -58,18 +50,12 @@ class Summarization(Summarizer):
     def get_summary(self, full_text: str) -> str:
         """
         Generates a summary using LLMChain for a given full text by breaking it into smaller chunks.
-
         **Parameters:**
-
         full_text (str): The full text to be summarized.
-
         **Returns:**
-
         str: The generated summary.
-
         """
         try:
-
             ## Split the full text into smaller text chunks
             text_chunks_into_docs = self.get_text_chunks_into_docs(full_text)
             text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=0)

--- a/tests/etl/__init__.py
+++ b/tests/etl/__init__.py
@@ -1,0 +1,1 @@
+from .test_summarize_etl import *

--- a/tests/etl/test_summarize_etl.py
+++ b/tests/etl/test_summarize_etl.py
@@ -1,11 +1,9 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-import postgrest
-
 from law_reader.common.RevisionSummaryInfo import RevisionSummaryInfo
-from law_reader.summarize_etl import get_revisions_without_summaries, download_bill_text, summarize_bill, upload_summary, summarize_all_unsummarized_revisions
-from supabase import Client, create_client
+from law_reader.db_interfaces import DBInterface
+from law_reader.summarize_etl import summarize_all_unsummarized_revisions
 
 from law_reader.summarizer.InvalidRTUniqueIDException import InvalidRTUniqueIDException
 from law_reader.summarizer.SummarizationException import SummarizationException
@@ -18,71 +16,14 @@ mock_revisions_data = [
 
 
 
-
-class TestGetRevisionsWithoutSummaries(unittest.TestCase):
-
-    def setUp(self):
-        # Mock the Client constructor
-        patcher = patch('supabase.Client.__init__', return_value=None)
-        self.mock_init = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        # Create a mock Client object
-        self.mock_client = Client(None, None)
-
-        # Mock the table method
-        patcher = patch('supabase.Client.table')
-        self.mock_table = patcher.start()
-        self.addCleanup(patcher.stop)
-
-
-
-
-    def test_non_empty_response(self):
-        """
-        Test that the function returns the correct number of results
-        and that the results contain the correct information
-        """
-        # Configure the mock for the table method
-        self.mock_table.return_value.select.return_value.is_.return_value.execute.return_value = MagicMock(data=mock_revisions_data)
-
-        # Call the function with the mock client
-        results = get_revisions_without_summaries(self.mock_client)
-
-        # Assertions
-        self.assertEqual(len(results), len(mock_revisions_data))
-        self.assertEqual(results[0].revision_guid, "guid1")
-
-    def test_empty_response(self):
-        """
-        Test that the function returns an empty list when the API call returns no results
-        """
-        # Configure the mock for the table method to return an empty list
-        self.mock_table.return_value.select.return_value.is_.return_value.execute.return_value = MagicMock(data=[])
-
-        # Call the function with the mock client
-        results = get_revisions_without_summaries(self.mock_client)
-
-        # Assertions
-        self.assertEqual(len(results), 0)
-
-    def test_api_error_handling(self):
-        # Mock the chained methods
-        mock_execute = self.mock_client.table("Revisions").select("*").is_("active_summary_id", "NULL")
-        mock_execute.execute = MagicMock(side_effect=Exception("API Error"))
-
-        # Verify that the function raises an exception when the API call fails
-        with self.assertRaises(Exception):
-            get_revisions_without_summaries(self.mock_client)
-
 class TestSummarizeAllUnsummarizedRevisions(unittest.TestCase):
 
     def setUp(self):
         # Mock all the functions used in summarize_all_unsummarized_revisions
-        self.mock_get_revisions_without_summaries = patch('law_reader.summarize_etl.get_revisions_without_summaries').start()
-        self.mock_download_bill_text = patch('law_reader.summarize_etl.download_bill_text').start()
+        db_interface_path = 'law_reader.db_interfaces.DBInterface'
         self.mock_summarize_bill = patch('law_reader.summarize_etl.summarize_bill').start()
-        self.mock_upload = patch('law_reader.summarize_etl.upload_summary').start()
+        self.mock_summarize_bill.return_value = "Summary text"
+
 
         # Add clean up to stop the patches after each test
         self.addCleanup(patch.stopall)
@@ -91,176 +32,68 @@ class TestSummarizeAllUnsummarizedRevisions(unittest.TestCase):
         self.mock_revision_info = MagicMock(spec=RevisionSummaryInfo)
         self.mock_revision_info.rt_unique_id = 1
 
-
-
-        # Mock the Client constructor
-        patcher = patch('supabase.Client.__init__', return_value=None)
-        self.mock_init = patcher.start()
-        self.addCleanup(patcher.stop)
-
-        # Create a mock Client object
-        self.mock_client = MagicMock(spec=Client)
+        # Create a mock DB interface
+        self.mock_db_interface = MagicMock(spec=DBInterface)
+        self.mock_db_interface.download_bill_text.return_value = "Full bill text"
 
     def test_with_revisions(self):
         """
         Tests that the function calls the correct functions the correct number of times
         """
         # Configure the mocks
-        self.mock_download_bill_text.return_value = "Full bill text"
-        self.mock_summarize_bill.return_value = "Summary text"
-
         mock_revisions = [self.mock_revision_info, self.mock_revision_info]
-        self.mock_get_revisions_without_summaries.return_value = mock_revisions
+
+        mdi = self.mock_db_interface
+        mdi.get_revisions_without_summaries.return_value = mock_revisions
 
         # Call the function with the mock client
-        summarize_all_unsummarized_revisions(self.mock_client)
+        summarize_all_unsummarized_revisions(self.mock_db_interface)
 
         # Assertions
-        self.mock_get_revisions_without_summaries.assert_called_once()
-        self.assertEqual(self.mock_download_bill_text.call_count, len(mock_revisions))
-        self.assertEqual(self.mock_summarize_bill.call_count, len(mock_revisions))
-        self.assertEqual(self.mock_upload.call_count, len(mock_revisions))
+        mdi.get_revisions_without_summaries.assert_called_once()
+        for methods in [mdi.download_bill_text, mdi.upload_summary, self.mock_summarize_bill]:
+            self.assertEqual(
+                methods.call_count,
+                len(mock_revisions),
+                msg=f"Expected {methods} to be called {len(mock_revisions)} times, but was called {methods.call_count} times")
 
     def test_no_revisions(self):
         """
         Tests that the function does not call any functions except for get_revisions_without_summaries
         when there are no revisions
         """
-        self.mock_get_revisions_without_summaries.return_value = []
+        mdi = self.mock_db_interface
+        mdi.get_revisions_without_summaries.return_value = []
 
-        summarize_all_unsummarized_revisions(self.mock_client)
+        summarize_all_unsummarized_revisions(self.mock_db_interface)
 
-        self.mock_get_revisions_without_summaries.assert_called_once()
-        self.mock_download_bill_text.assert_not_called()
-        self.mock_summarize_bill.assert_not_called()
-        self.mock_upload.assert_not_called()
+        mdi.get_revisions_without_summaries.assert_called_once()
+        for methods in [mdi.download_bill_text, mdi.upload_summary, self.mock_summarize_bill]:
+            methods.assert_not_called()
 
     def test_summarization_error_handling(self):
         """
         Tests that the function does not call upload_summary if the summarization fails
         """
-        self.mock_get_revisions_without_summaries.return_value = [self.mock_revision_info]
-        self.mock_download_bill_text.return_value = "Full bill text"
+        self.mock_db_interface.get_revisions_without_summaries.return_value = [self.mock_revision_info]
         self.mock_summarize_bill.side_effect = SummarizationException("Error")
 
-        summarize_all_unsummarized_revisions(self.mock_client)
+        summarize_all_unsummarized_revisions(self.mock_db_interface)
 
         self.mock_summarize_bill.assert_called_once()
-        self.mock_upload.assert_not_called()
+        self.mock_db_interface.upload_summary.assert_not_called()
 
     def test_download_bill_text_error_handling(self):
         """
         Tests that the function does not call summarize_bill or upload_summary if the download fails
         """
-        self.mock_get_revisions_without_summaries.return_value = [self.mock_revision_info]
-        self.mock_download_bill_text.side_effect = InvalidRTUniqueIDException("Error")
+        mdi = self.mock_db_interface
+        mdi.get_revisions_without_summaries.return_value = [self.mock_revision_info]
+        mdi.download_bill_text.side_effect = InvalidRTUniqueIDException("Error")
 
-        summarize_all_unsummarized_revisions(self.mock_client)
+        summarize_all_unsummarized_revisions(self.mock_db_interface)
 
-        self.mock_download_bill_text.assert_called_once()
+        mdi.download_bill_text.assert_called_once()
         self.mock_summarize_bill.assert_not_called()
-        self.mock_upload.assert_not_called()
+        mdi.upload_summary.assert_not_called()
 
-
-class TestDownloadBillText(unittest.TestCase):
-
-    def setUp(self):
-
-        # Create a mock Client object
-        self.mock_client = MagicMock(spec=Client)
-
-        # Create a mock API response
-        self.mock_api_response = MagicMock(spec=postgrest.APIResponse)
-
-    def set_mock_api_response(self, data):
-        self.mock_api_response.data = data
-        self.mock_client.table.return_value.select.return_value.eq.return_value.execute.return_value = self.mock_api_response
-
-    def test_download_bill_text(self):
-
-        # Setup mock return values for Supabase API call
-        self.set_mock_api_response([{"full_text": "Full text of the bill"}])
-
-        # Test the function with a mock Supabase client and a dummy ID
-        bill_text = download_bill_text(self.mock_client, 123)
-        self.assertEqual(bill_text, "Full text of the bill")
-
-    def test_download_bill_text_empty_api_response(self):
-        """
-        In the case of an empty API response, the function should raise an InvalidRTUniqueIDException
-        """
-        # Setup mock return values for Supabase API call
-        self.set_mock_api_response([])
-
-        # Test handling of empty API response
-        with self.assertRaises(InvalidRTUniqueIDException):
-            download_bill_text(self.mock_client, 123)
-
-    def test_download_bill_text_multiple_api_responses(self):
-        """
-        In the case of multiple API responses, the function should raise an InvalidRTUniqueIDException
-        """
-        # Setup mock return values for Supabase API call
-        self.set_mock_api_response([{"full_text": "Full text of the bill"}, {"full_text": "Another bill"}])
-
-        # Test handling of multiple API responses
-        with self.assertRaises(InvalidRTUniqueIDException):
-            download_bill_text(self.mock_client, 123)
-
-    def test_download_bill_text_no_text(self):
-        """
-        In the case of an empty API response, the function should raise an InvalidRTUniqueIDException
-        """
-        # Setup mock return values for Supabase API call
-        self.set_mock_api_response([{"full_text": ""}])
-
-        # Test handling of empty API response
-        with self.assertRaises(InvalidRTUniqueIDException):
-            download_bill_text(self.mock_client, 123)
-
-
-
-class TestSummarizeBill(unittest.TestCase):
-
-    @patch('law_reader.summarize_etl.Summarization.__init__', return_value=None)
-    @patch('law_reader.summarize_etl.Summarization.get_summary')
-    def test_summarize_bill(self, mock_get_summary, mock_init):
-        # Setup mock return value
-        mock_get_summary.return_value = "Mock Summary"
-
-        # Test with valid input
-        summary = summarize_bill("Sample bill text")
-        mock_get_summary.assert_called_once_with("Sample bill text")
-        self.assertEqual(summary, "Mock Summary")
-
-        # Test with empty input
-        summary = summarize_bill("")
-        mock_get_summary.assert_called_with("")
-        self.assertEqual(summary, "Mock Summary")
-
-class TestUploadSummary(unittest.TestCase):
-
-    def setUp(self) -> None:
-        # Create a mock Client object
-        self.mock_client = MagicMock(spec=Client)
-
-    """
-    Test successful upload
-    """
-    def test_upload_summary(self):
-        # Mock the API response for the insert call
-        self.mock_client.table.return_value.insert.return_value.execute.return_value = MagicMock(data=[{"summary_id": 1}])
-
-        # Create mock RevisionSummaryInfo object
-        mock_revision_info = MagicMock(spec=RevisionSummaryInfo)
-        mock_revision_info.revision_guid = "guid1"
-        mock_revision_info.revision_internal_id = 101
-
-        # Call the function with the mock client
-        upload_summary(self.mock_client, mock_revision_info, "Summary text")
-
-        # Assertions
-        self.mock_client.table.return_value.insert.assert_called_once_with({"summary_text": "Summary text", "revision_internal_id": 101})
-        self.mock_client.table.return_value.update.assert_called_once_with({"active_summary_id": 1})
-        self.mock_client.table.return_value.update.return_value.eq.assert_called_once_with("revision_guid", "guid1")
-        self.mock_client.table.return_value.update.return_value.eq.return_value.execute.assert_called_once()


### PR DESCRIPTION


This is the first step of a multi-step process that aims to make the backend more test-friendly. I'm breaking it up into smaller components so that's it's easier to review.

DB Unit tests will be replaced with integration test. While this technically reduces our code coverage, the tests being removed involved a lot of mocking API calls and complex method chains, which will be better served by later integration tests. 