### PR TITLE
Postgres db interface

### DIFF
--- a/law_reader/db_interfaces/DBInterface.py
+++ b/law_reader/db_interfaces/DBInterface.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from law_reader import BillIdentifier
 from law_reader.common.RevisionSummaryInfo import RevisionSummaryInfo
 
 
@@ -16,23 +17,61 @@ class DBInterface(ABC):
         pass
 
     @abstractmethod
-    def download_bill_text(self, revison_internal_id: int) -> str:
+    def get_bill_internal_id(self, bill_identifier: BillIdentifier) -> str:
+        """
+        Gets the bill_internal_id of a bill from the Supabase table "Bills" using the bill's legislative_id.
+        :param bill_identifier: The BillIdentifier object for the bill
+        :return: The bill_internal_id of the bill
+        """
+        pass
+
+    @abstractmethod
+    def insert(self, table, row_column_dict: dict):
+        """
+        Inserts a row into the given table
+        :param table: The name of the table to insert into
+        :param row_column_dict: A dictionary containing the column names and values
+        :return: The id of the inserted row, or None if the insert failed
+        """
+        pass
+
+    @abstractmethod
+    def create_and_attempt_to_insert_revision(self, revision_rss_feed_entry, bill_identifier: BillIdentifier) -> bool:
+        """
+        Creates a new bill revision record in the database if it does not already exist.
+        :param revision_rss_feed_entry: The RSS feed entry for the bill revision
+        :param bill_identifier: The BillIdentifier object for the bill
+        :return: True if a new record was inserted, False if not
+        """
+        pass
+
+    @abstractmethod
+    def create_and_attempt_to_insert_bill(self, bill_identifier: BillIdentifier) -> bool:
+        """
+        Creates a new bill record in the database if it does not already exist.
+        :param bill_identifier: The BillIdentifier object for the bill
+        :return: True if a new record was inserted, False if not
+        """
+        pass
+
+    @abstractmethod
+    def download_bill_text(self, revision_guid: str) -> str:
         """
         Downloads the full text of a bill from the database
-        :param revison_internal_id: the unique id of the bill
+        :param revision_guid: the unique id of the bill
         :return: the full text of the bill
         """
         pass
 
-    def upload_summary(self, revision_info: RevisionSummaryInfo, summary_text: str):
+    def upload_summary(self, revision_guid: str, summary_text: str):
         """
         Uploads a summary to the database, linking it to the appropriate entry in the "Revisions" table
-        :param revision_info: the unique id of the bill
+        :param revision_guid: the unique id of the bill
         :param summary_text: the text of the summary
         """
         pass
 
-    def get_revisions_without_summaries(self) -> list[RevisionSummaryInfo]:
+    def get_revisions_without_summaries(self) -> list[str]:
         """
         Gets the unique ids of all bills without summaries
         :return: a list of unique ids of bills without summaries

--- a/law_reader/db_interfaces/PostgresDBInterface.py
+++ b/law_reader/db_interfaces/PostgresDBInterface.py
@@ -1,0 +1,126 @@
+import psycopg2
+
+from law_reader import DBInterface, BillIdentifier, InvalidRTUniqueIDException
+from law_reader.common.RevisionSummaryInfo import RevisionSummaryInfo
+
+
+class PostgresDBInterface(DBInterface):
+    """
+    Interface for Postgres database classes.
+    Utilizes psycopg2 library.
+    """
+
+    def __init__(self, db_password, db_host):
+        super().__init__()
+        self.connection = psycopg2.connect(
+            dbname="postgres",
+            user="postgres",
+            password=db_password,
+            host=db_host,
+            port="54322"
+        )
+        self.cursor = self.connection.cursor()
+
+    def get_tables(self):
+        self.execute("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'")
+        return self.fetchall()
+
+    def insert(self, table, row_column_dict: dict, return_column: str = ""):
+        """
+        Inserts a row into the given table
+        :param table: The name of the table to insert into
+        :param row_column_dict: A dictionary containing the column names and values
+        :return: The id of the inserted row, or None if the insert failed
+        """
+        sql_script = f"INSERT INTO \"{table}\" ("
+        for column in row_column_dict.keys():
+            sql_script += f"{column}, "
+        sql_script = sql_script[:-2] + ") VALUES ("
+        for column in row_column_dict.keys():
+            sql_script += f"%({column})s, "
+        sql_script = sql_script[:-2] + ")"
+        if return_column != "":
+            sql_script += f" RETURNING {return_column}"
+        self.execute(sql_script, row_column_dict)
+        if return_column != "":
+            return self.fetchone()[0]
+
+
+    def get_bill_internal_id(self, bill_identifier: BillIdentifier) -> str:
+        pass
+
+    def create_and_attempt_to_insert_revision(self, revision_rss_feed_entry, bill_identifier: BillIdentifier) -> bool:
+        pass
+
+    def create_and_attempt_to_insert_bill(self, bill_identifier: BillIdentifier) -> bool:
+        pass
+
+    def download_bill_text(self, revision_guid: str) -> str:
+        """
+        Downloads the full text of a bill from the database, using the rt_unique_id
+        Raises an InvalidRTUniqueIDException if the bill cannot be found
+         or if multiple bills are found with the given rt_unique_id
+        :param rt_unique_id: the unique id of the bill in the Revision_Text table
+        :return: the full text of the bill
+        """
+        self.execute("SELECT full_text FROM \"Revision_Text\" WHERE revision_guid = %s", (revision_guid,))
+        result = self.fetchall()
+        if result is None:
+            raise InvalidRTUniqueIDException(f"Could not find bill with revision_guid {revision_guid}")
+        elif len(result) > 1:
+            raise InvalidRTUniqueIDException(f"Found multiple bills with revision_guid {revision_guid}")
+        text = result[0][0]
+        if text is None or text == "":
+            raise InvalidRTUniqueIDException(f"Bill with revision_guid {revision_guid} has no text")
+        return text
+
+    def upload_summary(self, revision_guid: str, summary_text: str):
+        """
+        Uploads a summary to the database, linking it to the appropriate entry in the "Revisions" table
+        :param revision_guid: a RevisionSummaryInfo object containing information about the revision
+        :param summary_text: the text of the summary
+        :return: The id of the inserted row, or None if the insert failed
+        """
+        # Insert summary into Summaries table and retrieve the summary_id of the new entry
+        summary_insert_dict = {
+            "summary_text": summary_text,
+            "revision_guid": revision_guid
+        }
+        summary_id = self.insert("Summaries", summary_insert_dict, "id")
+        active_summary_dict = {
+            "revision_guid": revision_guid,
+            "summaries_id": summary_id
+        }
+        # Insert summary into Active_Summaries table
+        self.insert("Active_Summaries", active_summary_dict)
+        return summary_id
+
+    def get_revisions_without_summaries(self) -> list[str]:
+        """
+        Gets the unique ids of all bills without summaries
+        :return: A list of RevisionSummaryInfo objects for the bills without summaries
+        """
+        self.execute("SELECT r.revision_guid FROM \"Revisions\" r "
+                     "LEFT JOIN \"Active_Summaries\" a ON r.revision_guid = a.revision_guid "
+                     "WHERE a.revision_guid IS NULL")
+        result = self.fetchall()
+        return [revision_guid for revision_guid in result]
+
+    def close(self):
+        self.cursor.close()
+        self.connection.close()
+
+    def execute(self, query, params=None):
+        self.cursor.execute(query, params)
+
+    def fetchone(self):
+        return self.cursor.fetchone()
+
+    def fetchall(self):
+        return self.cursor.fetchall()
+
+    def commit(self):
+        self.connection.commit()
+
+    def rollback(self):
+        self.connection.rollback()

--- a/tests_integration/test_postgres_db_interface.py
+++ b/tests_integration/test_postgres_db_interface.py
@@ -1,0 +1,134 @@
+import unittest
+
+from db_interfaces.PostgresDBInterface import PostgresDBInterface
+from law_reader.common.RevisionSummaryInfo import RevisionSummaryInfo
+
+class TestPostgresDBInterface(unittest.TestCase):
+
+        def setUp(self):
+            # Connect to Database Dev
+            self.db_interface = PostgresDBInterface(
+                db_password="postgres",
+                db_host="localhost")
+
+        def test_get_tables(self):
+            # Get the tables in the database
+            tables = self.db_interface.get_tables()
+            # Check that certain key tables are in the database
+            self.assertIn(("Bills",), tables)
+            self.assertIn(("Revisions",), tables)
+            self.assertIn(("Revision_Text",), tables)
+            self.assertIn(("Summaries",), tables)
+            self.assertIn(("Active_Summaries",), tables)
+
+        def test_insert(self):
+            bill_id = "11110SB111"
+            test_row = {
+                "legislative_id": bill_id,
+                "bill_number": "111",
+                "session_type": "0",
+                "chamber": "Senate",
+                "legislative_session": "1111",
+            }
+            # Insert a row into the Bills table
+            self.db_interface.insert("Bills", test_row)
+            # Check that the row was inserted
+            self.db_interface.execute("SELECT * FROM \"Bills\" WHERE legislative_id = %s", (bill_id,))
+            result = self.db_interface.fetchone()
+            self.assertIn(test_row["legislative_id"], result)
+
+        def test_upload_summary(self):
+            bill_id = "11110SB111"
+            revision_id = "11110SB111P2222"
+            # Insert a row into the Bills table
+            test_row = {
+                "legislative_id": bill_id,
+                "bill_number": "111",
+                "session_type": "0",
+                "chamber": "Senate",
+                "legislative_session": "1111",
+            }
+            self.db_interface.insert("Bills", test_row)
+
+            # Insert a row into the Revisions Table
+            revisions_row = {
+                "bill_id": bill_id,
+                "printer_no": "2222",
+                "full_text_link": "https://www.fakeurl.com/abc123xyz",
+                "publication_date": "2021-01-01",
+                "revision_guid": revision_id,
+                "description": "test",
+            }
+            self.db_interface.insert("Revisions", revisions_row)
+
+            # Upload a summary
+            test_summary = "This is a test summary"
+            summary_id = self.db_interface.upload_summary(revision_id, test_summary)
+            # Check that the summary was uploaded
+            self.db_interface.execute("SELECT * FROM \"Summaries\" WHERE id = %s", (summary_id,))
+            result = self.db_interface.fetchone()
+            self.assertIn(test_summary, result)
+
+        def test_download_bill_text(self):
+            # Insert a row into the Bills table
+            bill_id = "11110SB111"
+            revision_id = "11110SB111P2222"
+            test_row = {
+                "legislative_id": bill_id,
+                "bill_number": "111",
+                "session_type": "0",
+                "chamber": "Senate",
+                "legislative_session": "1111",
+            }
+            self.db_interface.insert("Bills", test_row)
+
+            # Insert a row into the Revisions Table
+            revisions_row = {
+                "bill_id": bill_id,
+                "printer_no": "2222",
+                "full_text_link": "https://www.fakeurl.com/abc123xyz",
+                "publication_date": "2021-01-01",
+                "revision_guid": "11110SB111P2222",
+                "description": "test",
+            }
+            self.db_interface.insert("Revisions", revisions_row)
+
+            # Insert a row into the Revision_Text table
+            revision_text_row = {
+                "full_text": "This is a test",
+                "revision_guid": revision_id
+            }
+            self.db_interface.insert("Revision_Text", revision_text_row)
+
+            # Download the bill text
+            text = self.db_interface.download_bill_text(revision_id)
+            self.assertIn("This is a test", text)
+
+        def test_get_revisions_without_summaries(self):
+            # Insert a row into the Bills table
+            bill_id = "11110SB111"
+            test_row = {
+                "legislative_id": bill_id,
+                "bill_number": "111",
+                "session_type": "0",
+                "chamber": "Senate",
+                "legislative_session": "1111",
+            }
+            self.db_interface.insert("Bills", test_row)
+
+            # Insert a row into the Revisions Table
+            revisions_row = {
+                "bill_id": bill_id,
+                "printer_no": "2222",
+                "full_text_link": "https://www.fakeurl.com/abc123xyz",
+                "publication_date": "2021-01-01",
+                "revision_guid": "11110SB111P2222",
+                "description": "test",
+            }
+            self.db_interface.insert("Revisions", revisions_row)
+
+            # Get the revisions without summaries
+            revisions = self.db_interface.get_revisions_without_summaries()
+            self.assertIn("11110SB111P2222", revisions[0])
+
+            # TODO: Update to also include revisions with summaries to further test


### PR DESCRIPTION
This expands the existing DB interface to encompass more methods, creates a Postgres DB Interface, and creates non-automated integration tests for the Postgres DB Interface. this interface is designed so that the Supabase Interface could be swapped out for this, significantly reducing coupling and offering a more intuitive set of internal methods. 