### PR TITLE
Implement loading specified environment at start of script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ __pycache__/
 
 # Temporary directory
 .temp/
+/.env.production
+/.env.stage
+/.env.development

--- a/law_reader/db_interfaces/PostgresDBInterface.py
+++ b/law_reader/db_interfaces/PostgresDBInterface.py
@@ -1,7 +1,6 @@
 import os
 
 import psycopg2
-from dotenv import load_dotenv
 
 from law_reader.common.RevisionSummaryInfo import RevisionSummaryInfo
 from law_reader import BillIdentifier, Revision
@@ -17,7 +16,6 @@ class PostgresDBInterface(DBInterface):
 
     def __init__(self):
         super().__init__()
-        load_dotenv()  # Load environment variables from .env file
 
         try:
             # Attempt to establish a connection

--- a/law_reader/db_interfaces/SupabaseDBInterface.py
+++ b/law_reader/db_interfaces/SupabaseDBInterface.py
@@ -2,7 +2,6 @@ import os
 
 from postgrest.types import CountMethod
 from supabase import Client, create_client
-from dotenv import load_dotenv
 
 from law_reader import BillIdentifier, Revision
 from law_reader.common.RevisionSummaryInfo import RevisionSummaryInfo
@@ -19,7 +18,6 @@ class SupabaseDBInterface(DBInterface):
         super().__init__()
         # if debug flag is set, pull data from .env file
         # In production, the environment variables will be set in the github actions workflow
-        load_dotenv()  # Load environment variables from .env file
         sb_api_url = os.environ.get("SUPABASE_API_URL")  # github actions secret management
         sb_api_key = os.environ.get("SUPABASE_API_KEY")  # github actions secret management
 

--- a/law_reader/docx_etl.py
+++ b/law_reader/docx_etl.py
@@ -1,3 +1,4 @@
+import argparse
 from typing import Optional
 
 from docx import Document
@@ -7,6 +8,7 @@ import requests
 
 from law_reader.db_interfaces.PostgresDBInterface import PostgresDBInterface
 from law_reader import DBInterface
+from util.load_environment import load_environment
 
 
 def make_temp_if_not_exists():
@@ -86,4 +88,11 @@ def extract_and_upload_missing_bill_text(db_interface: DBInterface):
     db_interface.commit()
 
 if __name__ == "__main__":
+    # Parse the arguments
+    parser = argparse.ArgumentParser(description="Extract and upload missing bill text from Database")
+    # Add a string argument for the environment, with a default value of an empty string
+    parser.add_argument('-e', '--environment', type=str, default='', help='The environment to run the script in')
+    # Load the environment variables
+    load_environment(parser.parse_args().environment)
+
     extract_and_upload_missing_bill_text(db_interface=PostgresDBInterface())

--- a/law_reader/rss_etl.py
+++ b/law_reader/rss_etl.py
@@ -1,8 +1,10 @@
+import argparse
 from dataclasses import asdict
 import feedparser
 
 from law_reader.db_interfaces import DBInterface, PostgresDBInterface
 from law_reader.common import BillIdentifier, Bill, Revision, LegislativeChamber
+from util.load_environment import load_environment
 
 """
 File for extracting data from the RSS feeds of the PA Senate and House of Representatives
@@ -179,5 +181,12 @@ def extract_from_rss_feed(leg_bod: str, rss_feed: str):
 
 
 if __name__ == "__main__":
+    # Parse the arguments
+    parser = argparse.ArgumentParser(description="Extract bills from RSS feeds")
+    # Add a string argument for the environment, with a default value of an empty string
+    parser.add_argument('-e', '--environment', type=str, default='', help='The environment to run the script in')
+    # Load the environment variables
+    load_environment(parser.parse_args().environment)
+
     extract_from_rss_feed(LegislativeChamber.SENATE.value, senate_rss_feed)
     extract_from_rss_feed(LegislativeChamber.HOUSE.value, house_rss_feed)

--- a/law_reader/summarize_etl.py
+++ b/law_reader/summarize_etl.py
@@ -6,6 +6,7 @@ from law_reader.common.RevisionSummaryInfo import RevisionSummaryInfo
 from law_reader.summarizer.InvalidRTUniqueIDException import InvalidRTUniqueIDException
 from law_reader.summarizer.SummarizationException import SummarizationException
 from law_reader.summarizer.summarization import Summarization
+from util.load_environment import load_environment
 
 """
 File for downloading full text of bills from Supabase, summarizing them, and uploading the summaries to Supabase
@@ -51,6 +52,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Summarize bills from Database")
     # Add a boolean argument for the debug flag
     parser.add_argument('-d', '--debug', action='store_true', help='Print debug messages')
+    # Add a string argument for the environment, with a default value of an empty string
+    parser.add_argument('-e', '--environment', type=str, default='', help='The environment to run the script in')
+    # Load the environment variables
+    load_environment(parser.parse_args().environment)
+
     # Parse the arguments
     args = parser.parse_args()
     db_interface: DBInterface = PostgresDBInterface()

--- a/law_reader/summarizer/summarization.py
+++ b/law_reader/summarizer/summarization.py
@@ -8,11 +8,9 @@ This module provides a class for generating summaries of text using OpenAI's GPT
 
 import os
 
-from dotenv import load_dotenv
 from langchain.chat_models import ChatOpenAI
 from langchain.chains import LLMChain
 from langchain.text_splitter import CharacterTextSplitter
-from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from langchain.prompts import PromptTemplate
 from langchain.docstore.document import Document
@@ -27,7 +25,6 @@ class Summarization(Summarizer):
 
     def __init__(self, llm=None):
         super().__init__(llm)
-        load_dotenv()  # Load environment variables from .env file
         api_key = os.environ['OPENAI_API_KEY']
 
         if not api_key:

--- a/tests_integration/test_etl_integration.py
+++ b/tests_integration/test_etl_integration.py
@@ -9,6 +9,7 @@ import law_reader.docx_etl as docx_etl
 import law_reader.summarize_etl as summarize_etl
 from law_reader.db_interfaces.PostgresDBInterface import PostgresDBInterface
 from law_reader import Extractor
+from util.load_environment import load_environment
 
 MOCK_RSS_FEED_DATA = {
     "entries": [
@@ -40,6 +41,10 @@ MOCK_RSS_FEED_DATA = {
 class TestETLIntegration(unittest.TestCase):
 
     def setUp(self) -> None:
+        # Load the environment variables
+        load_environment()
+
+        # Create a new instance of the database interface
         self.db_interface = PostgresDBInterface()
         # Truncate the tables in the database (SupabaseDBInterface)
         tables = ['Revisions', 'Bills', 'Revision_Text', 'Summaries']

--- a/tests_integration/test_postgres_db_interface.py
+++ b/tests_integration/test_postgres_db_interface.py
@@ -1,16 +1,17 @@
 import os
 import unittest
 
-from dotenv import load_dotenv
-
 from law_reader.db_interfaces.PostgresDBInterface import PostgresDBInterface
 from law_reader import BillIdentifier, Revision
+from util.load_environment import load_environment
+
 
 class TestPostgresDBInterface(unittest.TestCase):
 
 
         def setUp(self):
-            load_dotenv()  # Load environment variables from .env file
+            # Load the environment variables
+            load_environment()
 
             # Create a PostgresDBInterface object
             self.db_interface = PostgresDBInterface()

--- a/util/load_environment.py
+++ b/util/load_environment.py
@@ -1,0 +1,15 @@
+
+
+def load_environment(env_type: str = "") -> None:
+    """
+    Load environment variables from a .env file.
+    If no file is specified, it will load the default .env file in the current directory.
+    **Parameters:**
+    env_type (str): The type of environment to load. If not specified, it will load the default .env file.
+    """
+    from dotenv import load_dotenv
+    if not env_type:
+        load_dotenv()
+    else:
+        env_file = f".env.{env_type}"
+        load_dotenv(dotenv_path=env_file)


### PR DESCRIPTION
This was done to allow for easier swapping between different environments. 

Calls to "load_dotenv" were removed from subordinate scripts and instead added to the beginning of primary scripts, in some cases with arguments allowing the user to specify what, if any, environment they wish to load. If no environment is specified, the default environment is loaded. 

As designed, this shouldn't impact any existing workflow scripts, as in the absence of any development environment specified the scripts will default to the, well, default ".env" environment. But this will be useful during development where one might have to swap out different environment variables. 

Gitignore has correspondingly been updated as well. 